### PR TITLE
Refactor pluralization logic for TypeScript

### DIFF
--- a/genTypeScript.go
+++ b/genTypeScript.go
@@ -61,6 +61,7 @@ func genTypeScriptFieldName(name string) (fieldName string) {
 func genTypeScriptFieldType(name string, plural bool) (fieldType string) {
 	if _, ok := typeScriptBuildInType[name]; ok {
 		fieldType = name
+		return
 	}
 	for _, str := range strings.Split(name, ".") {
 		fieldType += MakeFirstUpperCase(str)

--- a/genTypeScript.go
+++ b/genTypeScript.go
@@ -153,10 +153,9 @@ func (gen *CodeGenerator) TypeScriptComplexType(v *ComplexType) {
 		for _, element := range v.Elements {
 			fieldType := genTypeScriptFieldType(getBasefromSimpleType(trimNSPrefix(element.Type), gen.ProtoTree))
 			if element.Plural {
-				content += fmt.Sprintf("\t%s: Array<%s>;\n", genTypeScriptFieldName(element.Name), fieldType)
-				continue
+				fieldType = fmt.Sprintf("Array<%s>", fieldType)
 			}
-			content += fmt.Sprintf("\t%s: Array<%s>;\n", genTypeScriptFieldName(element.Name), fieldType)
+			content += fmt.Sprintf("\t%s: %s;\n", genTypeScriptFieldName(element.Name), fieldType)
 		}
 		content += "}\n"
 		gen.StructAST[v.Name] = content

--- a/test/ts/base64.xsd.ts
+++ b/test/ts/base64.xsd.ts
@@ -11,9 +11,9 @@ export class MyType3 {
 }
 
 export class MyType4 {
-	Title: Array<string>;
-	Blob: Array<Array<any>>;
-	Timestamp: Array<string>;
+	Title: string;
+	Blob: Array<any>;
+	Timestamp: string;
 }
 
 export type MyType5 = string;


### PR DESCRIPTION
## Description

Fixes #15. This PR is a little more intrusive/comprehensive than #16.

This moves all pluralization-related logic for type-generation in TypeScript into the `genTypeScriptFieldType` method. This required changing the method signature.

I did not change any of the other languages. This approach would not be appropriate for C, where the type and its "pluralization" (`[]`) are separated by the name of the field.

## Related Issue

#15

## Motivation and Context

There is a lot of repetitive code for handling the `Array<>` logic. This PR simplifies the code and should make the behavior more consistent.

## How Has This Been Tested

The TS reference output has been updated and matches the version in #16.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Also, some refactoring

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
  - caveat: TS code-gen is now a little less similar to the other code-gen
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Note:** The branch name does not include the issue number. If the suggested fix is welcome but the branch name is a blocker, please let me know and I'll fix it.