### PR TITLE
Fix for #28: Attribute Enumeration Parsing Aborted Prematurely When Enclosed in ComplexType

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -58,7 +58,7 @@ func NewParser(options *Options) *Options {
 }
 
 // Parse reads XML documents and return proto tree for every element in the
-// documents by given options. If value of the properity extract is false,
+// documents by given options. If value of the property extract is false,
 // parse will fetch schema used in <import> or <include> statements.
 func (opt *Options) Parse() (err error) {
 	opt.FileDir = filepath.Dir(opt.FilePath)

--- a/test/c/base64.xsd.h
+++ b/test/c/base64.xsd.h
@@ -22,3 +22,9 @@ typedef struct {
 
 // MyType5 ...
 typedef char MyType5;
+
+// MyType6 ...
+typedef struct {
+	char CodeAttr; // attr, optional
+	int IdentifierAttr; // attr, optional
+} MyType6;

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -32,3 +32,10 @@ type MyType4 struct {
 
 // MyType5 ...
 type MyType5 time.Time
+
+// MyType6 ...
+type MyType6 struct {
+	XMLName        xml.Name `xml:"myType6"`
+	CodeAttr       string   `xml:"code,attr,omitempty"`
+	IdentifierAttr int      `xml:"identifier,attr,omitempty"`
+}

--- a/test/ts/base64.xsd.ts
+++ b/test/ts/base64.xsd.ts
@@ -22,3 +22,9 @@ export class MyType4 {
 
 // MyType5 ...
 export type MyType5 = string;
+
+// MyType6 ...
+export class MyType6 {
+	CodeAttr: string | null;
+	IdentifierAttr: number | null;
+}

--- a/test/xsd/base64.xsd
+++ b/test/xsd/base64.xsd
@@ -32,5 +32,17 @@
   <simpleType name="myType5">
     <restriction base="gDay"/>
   </simpleType>
+
+  <complexType name="myType6">
+    <attribute name="code">
+      <simpleType>
+        <restriction base="string">
+          <enumeration value="value1"/>
+          <enumeration value="value2"/>
+        </restriction>
+      </simpleType>
+    </attribute>
+    <attribute name="identifier" type="int"/>
+  </complexType>
 </schema>
 

--- a/xmlAttribute.go
+++ b/xmlAttribute.go
@@ -39,11 +39,6 @@ func (opt *Options) OnAttribute(ele xml.StartElement, protoTree []interface{}) (
 			}
 		}
 	}
-	if opt.ComplexType.Len() > 0 {
-		opt.ComplexType.Peek().(*ComplexType).Attributes = append(opt.ComplexType.Peek().(*ComplexType).Attributes, attribute)
-		return
-	}
-
 	opt.Attribute.Push(&attribute)
 	return
 }
@@ -55,6 +50,10 @@ func (opt *Options) EndAttribute(ele xml.EndElement, protoTree []interface{}) (e
 	}
 	if opt.AttributeGroup.Len() > 0 {
 		opt.AttributeGroup.Peek().(*AttributeGroup).Attributes = append(opt.AttributeGroup.Peek().(*AttributeGroup).Attributes, *opt.Attribute.Pop().(*Attribute))
+		return
+	}
+	if opt.ComplexType.Len() > 0 {
+		opt.ComplexType.Peek().(*ComplexType).Attributes = append(opt.ComplexType.Peek().(*ComplexType).Attributes, *opt.Attribute.Pop().(*Attribute))
 		return
 	}
 	if opt.ComplexType.Len() == 0 {


### PR DESCRIPTION
# PR Details

This fixes the parsing of attributes defined with enumerations and enclosed in complex types. Before the change proposed here, attributes of a complex type that were defined with enumerations would render without a type (in `go`, that meant `interface{}`) and other attributes in that enclosing complex types would be missing. Issue #28 has an example of this and this PR includes a new type that is an example of this. 

## Description

This is my first contribution so I'm just getting familiar with the code base but it looks like the problem was that the attribute was prematurely added to the enclosing complex type in the attribute start instead of in the end. This had the side-effect of clearing the attribute from the stack and improperly including the restriction and enumeration data enclosed in the attribute when present. 

To fix this, I moved that logic to add the attribute to the parent type in the `EndAttribute`. For the example added to base64.xsd, this looks correct. 

## Related Issue

https://github.com/xuri/xgen/issues/28

## Motivation and Context

This fixes one issue I was having with generating go structs from a somewhat complex (but valid) XSD. The main problem was that a lot of fields were missing in types that included enumerations but also, as stated earlier, the type for the attribute was incorrectly erased and generated as `interface{}`. 

## How Has This Been Tested

I ran the test on the modified `base64.xsd` and validated that it looks correct. I then updated the expected generated code to ensure the tests would pass. 

***Note that some expected results for tests in https://github.com/xuri/xsd need to be updated because they were affected by the bug and had incorrect expectations that need to be changed:***
 * maven.apache.org/fml-1.0.1.xsd
 * fml-1.0.xsd 
 * xdoc-2.0.xsd

Question: I didn't see anything in the contribution guidelines regarding tests in https://github.com/xuri/xsd for which the expected output needed to be changed as part of a bugfix. Should I open a parallel PR in https://github.com/xuri/xsd to update those? 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
