### PR TITLE
Add Support for xsd:choice plurality

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -49,6 +49,7 @@ type Options struct {
 	Attribute      *Stack
 	Group          *Stack
 	AttributeGroup *Stack
+	Choice         *Stack
 }
 
 // NewParser creates a new parser options for the Parse. Useful for XML schema
@@ -94,6 +95,7 @@ func (opt *Options) Parse() (err error) {
 	opt.Attribute = NewStack()
 	opt.Group = NewStack()
 	opt.AttributeGroup = NewStack()
+	opt.Choice = NewStack()
 
 	decoder := xml.NewDecoder(xmlFile)
 	decoder.CharsetReader = charset.NewReaderLabel

--- a/proto.go
+++ b/proto.go
@@ -75,6 +75,7 @@ type ComplexType struct {
 	Elements       []Element
 	Attributes     []Attribute
 	Groups         []Group
+	Choice         []Choice
 	AttributeGroup []AttributeGroup
 	Mixed          bool
 }
@@ -91,6 +92,19 @@ type Group struct {
 	Groups   []Group
 	Plural   bool
 	Ref      string
+}
+
+// Choice definitions are provided primarily for reference from
+// the XML Representation of Choice Definitions which acts as a container
+// stating that one and only one element in the selected group should be
+// present in the containing element. Generated code does not enforce the "one
+// and only one" constraint but the choice container is parsed in order to effectively
+// define if the elements it contains should be plural or not (as defined by the maxOccurs).
+// https://www.w3.org/TR/xmlschema-1/#Complex_Type_Definition_details
+type Choice struct {
+	ID       string
+	Choice   []Choice
+	Plural   bool
 }
 
 // AttributeGroup definitions do not participate in ·validation· as such, but

--- a/test/c/base64.xsd.h
+++ b/test/c/base64.xsd.h
@@ -39,4 +39,6 @@ typedef struct {
 	float CostAttr; // attr, optional
 	char LastUpdatedAttr; // attr, optional
 	MyType7 Nested;
+	char MyType1[];
+	MyType2 MyType2[];
 } TopLevel;

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -48,8 +48,10 @@ type MyType7 struct {
 
 // TopLevel ...
 type TopLevel struct {
-	CostAttr        float64  `xml:"cost,attr,omitempty"`
-	LastUpdatedAttr string   `xml:"LastUpdated,attr,omitempty"`
-	Nested          *MyType7 `xml:"nested"`
+	CostAttr        float64    `xml:"cost,attr,omitempty"`
+	LastUpdatedAttr string     `xml:"LastUpdated,attr,omitempty"`
+	Nested          *MyType7   `xml:"nested"`
+	MyType1         [][]byte   `xml:"myType1"`
+	MyType2         []*MyType2 `xml:"myType2"`
 	*MyType6
 }

--- a/test/java/base64.xsd.java
+++ b/test/java/base64.xsd.java
@@ -76,4 +76,8 @@ public class TopLevel extends MyType6  {
 	protected String LastUpdatedAttr;
 	@XmlElement(required = true, name = "nested")
 	protected MyType7 Nested;
+	@XmlElement(required = true, name = "myType1")
+	protected List<List<Byte>> MyType1;
+	@XmlElement(required = true, name = "myType2")
+	protected List<MyType2> MyType2;
 }

--- a/test/rs/base64.xsd.rs
+++ b/test/rs/base64.xsd.rs
@@ -85,6 +85,10 @@ pub struct TopLevel {
 	pub last_updated: Option<u8>,
 	#[serde(rename = "nested")]
 	pub nested: MyType7,
+	#[serde(rename = "myType1")]
+	pub my_type1: Vec<String>,
+	#[serde(rename = "myType2")]
+	pub my_type2: Vec<MyType2>,
 	#[serde(flatten)]
 	pub my_type6: MyType6,
 }

--- a/test/ts/base64.xsd.ts
+++ b/test/ts/base64.xsd.ts
@@ -42,4 +42,6 @@ export class TopLevel extends MyType6  {
 	CostAttr: number | null;
 	LastUpdatedAttr: string | null;
 	Nested: MyType7;
+	MyType1: Uint8Array;
+	MyType2: Array<MyType2>;
 }

--- a/test/xsd/base64.xsd
+++ b/test/xsd/base64.xsd
@@ -59,6 +59,10 @@
         <extension base="here:MyType6">
           <sequence>
             <element name="nested" type="here:MyType7" minOccurs="0" maxOccurs="1" />
+            <choice minOccurs="0" maxOccurs="unbounded">
+              <element name="myType1" type="here:myType1" />
+              <element name="myType2" type="here:myType2" />
+            </choice>
           </sequence>
           <attribute name="cost" type="double"/>
           <attribute name="LastUpdated" type="dateTime"/>

--- a/xmlChoice.go
+++ b/xmlChoice.go
@@ -1,0 +1,52 @@
+// Copyright 2021 The xgen Authors. All rights reserved. Use of this source
+// code is governed by a BSD-style license that can be found in the LICENSE
+// file.
+//
+// Package xgen written in pure Go providing a set of functions that allow you
+// to parse XSD (XML schema files). This library needs Go version 1.10 or
+// later.
+
+package xgen
+
+import (
+	"encoding/xml"
+	"strconv"
+)
+
+// OnChoice handles parsing event on the choice start elements. The
+// choice element defines that one and only one of the contained element can be present within
+// the contained element.
+func (opt *Options) OnChoice(ele xml.StartElement, protoTree []interface{}) (err error) {
+	choice := Choice{}
+	for _, attr := range ele.Attr {
+		if attr.Name.Local == "maxOccurs" {
+			var maxOccurs int
+			if maxOccurs, err = strconv.Atoi(attr.Value); attr.Value != "unbounded" && err != nil {
+				return
+			}
+			if attr.Value == "unbounded" || maxOccurs > 1 {
+				choice.Plural, err = true, nil
+			} else {
+				choice.Plural, err = false, nil
+			}
+		}
+	}
+	// Handle a case of a parent choice having plurality that children should inherit
+	if opt.Choice.Len() > 0 {
+		choice.Plural = choice.Plural || opt.Choice.Peek().(*Choice).Plural
+	}
+
+	opt.CurrentEle = opt.InElement
+	opt.Choice.Push(&choice)
+
+	return
+}
+
+// EndChoice handles parsing event on the choice end elements.
+func (opt *Options) EndChoice(ele xml.EndElement, protoTree []interface{}) (err error) {
+	choice := opt.Choice.Pop().(*Choice)
+	opt.ProtoTree = append(opt.ProtoTree, choice)
+	opt.CurrentEle = ""
+
+	return
+}

--- a/xmlFixtures/base64.xml
+++ b/xmlFixtures/base64.xml
@@ -1,3 +1,7 @@
 <TopLevel cost="1.25" LastUpdated="2021-09-14T12:04:09.69" code="not found" identifier="10">
     <nested origin="internet">Destination-Host</nested>
+    <myType1>dGVzdA==</myType1>
+    <myType1>dGVzdDI=</myType1>
+    <myType2 length="2">te</myType2>
+    <myType2 length="4">test</myType2>
 </TopLevel>

--- a/xmlGroup.go
+++ b/xmlGroup.go
@@ -32,6 +32,10 @@ func (opt *Options) OnGroup(ele xml.StartElement, protoTree []interface{}) (err 
 			}
 		}
 	}
+	if opt.Choice.Len() > 0 {
+		group.Plural = group.Plural || opt.Choice.Peek().(*Choice).Plural
+	}
+
 	if opt.ComplexType.Len() == 0 {
 		if opt.InGroup == 0 {
 			opt.InGroup++


### PR DESCRIPTION
# PR Details

This adds support for xsd:choice plurality. All elements contained in a xsd:choice now
get to be plural if either the element or the containing choice are plural.

Fixes #38.

## Description

This adds handling of [xsd:choice](https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/ms256109(v=vs.100)). It supports choices being enclosed within other choices in order to properly set the plurality of elements. All cases are relatively simple since singular elements get upgraded to plural as soon as one of its containing choice elements is declared as plural or the element itself is plural. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

I have an xsd that uses choices to basically state that there are multiple occurrences where each occurrence can be of any one type enclosed in that choice. Because xgen doesn't generate any validation code, the only information required to be propagated to the generated code is the correct plurality. 

## How Has This Been Tested

Added coverage in the base64.xsd, updated the base64.xml example and made sure all tests are passing. Furthermore, I ran `xgen` on my own real-world use-case and made sure that the generated code would marshal/unmarshal the real-world XML correctly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
