### PR TITLE
Fix Skipped Groups After Addition of Choice Plurality Support

### DIFF
--- a/xmlChoice.go
+++ b/xmlChoice.go
@@ -36,7 +36,6 @@ func (opt *Options) OnChoice(ele xml.StartElement, protoTree []interface{}) (err
 		choice.Plural = choice.Plural || opt.Choice.Peek().(*Choice).Plural
 	}
 
-	opt.CurrentEle = opt.InElement
 	opt.Choice.Push(&choice)
 
 	return
@@ -44,9 +43,7 @@ func (opt *Options) OnChoice(ele xml.StartElement, protoTree []interface{}) (err
 
 // EndChoice handles parsing event on the choice end elements.
 func (opt *Options) EndChoice(ele xml.EndElement, protoTree []interface{}) (err error) {
-	choice := opt.Choice.Pop().(*Choice)
-	opt.ProtoTree = append(opt.ProtoTree, choice)
-	opt.CurrentEle = ""
+	opt.Choice.Pop()
 
 	return
 }


### PR DESCRIPTION
# PR Details

This fixes the issue identified by @xuri [here](https://github.com/xuri/xgen/pull/39#issuecomment-982217295). 

## Description

In the addition of support for choice plurality in https://github.com/xuri/xgen/pull/39, I had leftover copy-pasta that was setting the current element which interfered with the processing of groups. This removes the extra copy-pasted code that wasn't needed for processing `choice` elements and introduced the issue. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
