### PR TITLE
fixed upper case first rune for Unicode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
+	golang.org/x/text v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/utils.go
+++ b/utils.go
@@ -9,7 +9,6 @@
 package xgen
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -20,6 +19,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 var (
@@ -182,17 +183,21 @@ func trimNSPrefix(str string) (name string) {
 
 // MakeFirstUpperCase make the first letter of a string uppercase.
 func MakeFirstUpperCase(s string) string {
+	return ToTitle(s)
+}
 
-	if len(s) < 2 {
-		return strings.ToUpper(s)
+func ToTitle(val string) string {
+	var buf strings.Builder
+	buf.Grow(utf8.UTFMax * len(val))
+
+	for i, rune := range val {
+		if i == 0 {
+			rune = unicode.ToUpper(rune)
+		}
+		buf.WriteRune(rune)
 	}
 
-	bts := []byte(s)
-
-	lc := bytes.ToUpper([]byte{bts[0]})
-	rest := bts[1:]
-
-	return string(bytes.Join([][]byte{lc, rest}, nil))
+	return buf.String()
 }
 
 // callFuncByName calls the no error or only error return function with
@@ -256,7 +261,7 @@ func genFieldComment(name, doc, prefix string) string {
 }
 
 type kvPair struct {
-	key string
+	key   string
 	value string
 }
 

--- a/xml_test.go
+++ b/xml_test.go
@@ -2,12 +2,13 @@ package xgen
 
 import (
 	"encoding/xml"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	schema "github.com/xuri/xgen/test/go"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	schema "github.com/xuri/xgen/test/go"
 )
 
 // TestGeneratedGo runs through test cases to validate Go generated structs. Each test case
@@ -17,7 +18,7 @@ import (
 func TestGeneratedGo(t *testing.T) {
 	testCases := []struct {
 		// xmlFileName is the path to the xml fixture file to unmarshal into the receiving struct
-		xmlFileName     string
+		xmlFileName string
 		// receivingStruct is a pointer to the struct to unmarshal the xml file content into. It should match
 		// the type of the top level element present in that file
 		receivingStruct interface{}
@@ -49,4 +50,20 @@ func TestGeneratedGo(t *testing.T) {
 			assert.Equal(t, string(input), string(remarshaled))
 		})
 	}
+}
+
+func TestToTitle(t *testing.T) {
+	test := func(expected, actual string) {
+		assert.Equal(t, expected, ToTitle(actual))
+	}
+
+	test("", "")
+	test("A", "a")
+	test("Ab", "ab")
+	test("A b", "a b")
+	test("Ab cd", "ab cd")
+
+	// Test Сyrillic (`привет мир` → `hello world`)
+	test("Привет", "привет")
+	test("Привет мир", "привет мир")
 }


### PR DESCRIPTION
* before it produces mess for Cyrillic tag names

Thank you for your library!

# PR Details

I used this library to convert XSD on with Cyrillic (cp1251) characters. 

## Description

Unfortunately, it produces the wrong result in the image below. 

![image](https://user-images.githubusercontent.com/1235527/150207774-d97897ad-a1df-447f-89e4-f7ec760bbb58.png)

I fixed `MakeFirstUpperCase` function to convert Unicode characters properly.

Now it's correct.

![image](https://user-images.githubusercontent.com/1235527/150208199-3ffcc616-cd18-4a66-bf82-fa164265ce2e.png)

Raw XSD file for testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
