### PR TITLE
Fix float to float32 for Golang

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -96,7 +96,7 @@ var BuildInTypes = map[string][]string{
 	"decimal":            {"float64", "number", "float", "Float", "f64"},
 	"double":             {"float64", "number", "float", "Float", "f64"},
 	"duration":           {"string", "string", "char", "String", "String"},
-	"float":              {"float", "number", "float", "Float", "f64"},
+	"float":              {"float32", "number", "float", "Float", "f64"},
 	"gDay":               {"string", "string", "char", "String", "String"},
 	"gMonth":             {"string", "string", "char", "String", "String"},
 	"gMonthDay":          {"string", "string", "char", "String", "String"},


### PR DESCRIPTION
## Description

My XSD contains xs:float type:
```text
<xs:element type="xs:float" name="Mark"/>
```
Generates to:
```text
Mark                      *Float                     `xml:"Mark"`
```
After this fix it generates to
```text
Mark                      float32                     `xml:"Mark"`
```
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
