### PR TITLE
Fix directory creation and filename extension handling

### DIFF
--- a/cmd/xgen/xgen.go
+++ b/cmd/xgen/xgen.go
@@ -100,10 +100,6 @@ func parseFlags() *Config {
 
 func main() {
 	cfg := parseFlags()
-	if err := xgen.PrepareOutputDir(cfg.O); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
 	files, err := xgen.GetFileList(cfg.I)
 	if err != nil {
 		fmt.Println(err)

--- a/genC.go
+++ b/genC.go
@@ -45,7 +45,7 @@ func (gen *CodeGenerator) GenC() error {
 		funcName := fmt.Sprintf("C%s", reflect.TypeOf(ele).String()[6:])
 		callFuncByName(gen, funcName, []reflect.Value{reflect.ValueOf(ele)})
 	}
-	f, err := os.Create(gen.File + ".h")
+	f, err := os.Create(gen.FileWithExtension(".h"))
 	if err != nil {
 		return err
 	}

--- a/genGo.go
+++ b/genGo.go
@@ -67,7 +67,7 @@ func (gen *CodeGenerator) GenGo() error {
 		funcName := fmt.Sprintf("Go%s", reflect.TypeOf(ele).String()[6:])
 		callFuncByName(gen, funcName, []reflect.Value{reflect.ValueOf(ele)})
 	}
-	f, err := os.Create(gen.File + ".go")
+	f, err := os.Create(gen.FileWithExtension(".go"))
 	if err != nil {
 		return err
 	}
@@ -325,4 +325,14 @@ func (gen *CodeGenerator) GoAttribute(v *Attribute) {
 		fieldName := genGoFieldName(v.Name, true)
 		gen.Field += fmt.Sprintf("%stype %s%s", genFieldComment(fieldName, v.Doc, "//"), fieldName, gen.StructAST[v.Name])
 	}
+}
+
+func (gen *CodeGenerator) FileWithExtension(extension string) string {
+	if !strings.HasPrefix(extension, ".") {
+		extension = "." + extension
+	}
+	if strings.HasSuffix(gen.File, extension) {
+		return gen.File
+	}
+	return gen.File + extension
 }

--- a/genJava.go
+++ b/genJava.go
@@ -40,7 +40,7 @@ func (gen *CodeGenerator) GenJava() error {
 		funcName := fmt.Sprintf("Java%s", reflect.TypeOf(ele).String()[6:])
 		callFuncByName(gen, funcName, []reflect.Value{reflect.ValueOf(ele)})
 	}
-	f, err := os.Create(gen.File + ".java")
+	f, err := os.Create(gen.FileWithExtension(".java"))
 	if err != nil {
 		return err
 	}

--- a/genRust.go
+++ b/genRust.go
@@ -104,7 +104,7 @@ func (gen *CodeGenerator) GenRust() error {
 		funcName := fmt.Sprintf("Rust%s", reflect.TypeOf(ele).String()[6:])
 		callFuncByName(gen, funcName, []reflect.Value{reflect.ValueOf(ele)})
 	}
-	f, err := os.Create(gen.File + ".rs")
+	f, err := os.Create(gen.FileWithExtension(".rs"))
 	if err != nil {
 		return err
 	}

--- a/genTypeScript.go
+++ b/genTypeScript.go
@@ -36,7 +36,7 @@ func (gen *CodeGenerator) GenTypeScript() error {
 		funcName := fmt.Sprintf("TypeScript%s", reflect.TypeOf(ele).String()[6:])
 		callFuncByName(gen, funcName, []reflect.Value{reflect.ValueOf(ele)})
 	}
-	f, err := os.Create(gen.File + ".ts")
+	f, err := os.Create(gen.FileWithExtension(".ts"))
 	if err != nil {
 		return err
 	}

--- a/xml_test.go
+++ b/xml_test.go
@@ -67,3 +67,46 @@ func TestToTitle(t *testing.T) {
 	test("Привет", "привет")
 	test("Привет мир", "привет мир")
 }
+
+func TestCodeGeneratorFileWithExtension(t *testing.T) {
+	testCases := []struct {
+		description string
+		filename    string
+		extension   string
+		expected    string
+	}{
+		{
+			description: "filename without extension and extension without period should add extension",
+			filename:    "foo",
+			extension:   "java",
+			expected:    "foo.java",
+		},
+		{
+			description: "filename without extension and extension with period should add extension",
+			filename:    "foo",
+			extension:   ".java",
+			expected:    "foo.java",
+		},
+		{
+			description: "filename with extension already should not add extension",
+			filename:    "foo.java",
+			extension:   ".java",
+			expected:    "foo.java",
+		},
+		{
+			description: "filename with different extension should add extension",
+			filename:    "foo.bar",
+			extension:   ".java",
+			expected:    "foo.bar.java",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			gen := CodeGenerator{
+				File: tc.filename,
+			}
+			actual := gen.FileWithExtension(tc.extension)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION


# PR Details

Fix directory creation and filename extension handling

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug where xgen assumes that the output path provided by the user is a directory. This removes the call to PrepareOutputDir from xgen.go, but this should be fine because PrepareOutputDir is also called, correctly, in parser.go.

Fixes a bug where the language-specific generator code assumes that the output path does not contain the file extension. This commit adds a helper function called FileWithExtension that checks to see if the extension already exists on the filename and does not add it again if it does.

<!--- Describe your changes in detail -->

## Related Issue

Fixes #56 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Unit tests and manual tests (see below).

```
$ go run cmd/xgen/xgen.go -l Java -i test/xsd/base64.xsd -o output.java
done
$ ls -la | grep output
-rw-rw-r--  1 bpursley bpursley  2066 Jul 20 10:05 output.java
```
```
$ go run cmd/xgen/xgen.go -l Java -i test/xsd/base64.xsd -o output
done
$ ls -la | grep output
-rw-rw-r--  1 bpursley bpursley  2066 Jul 20 10:06 output.java
```
```
$ go run cmd/xgen/xgen.go -l Java -i test/xsd/base64.xsd
done
$ ls -la | grep xgen_out
-rw-rw-r--  1 bpursley bpursley  2066 Jul 20 10:06 xgen_out.java
```
```
$ go run cmd/xgen/xgen.go -l Java -i test/xsd -o output
done
$ ls -la | grep output
drwxr-xr-x  2 bpursley bpursley  4096 Jul 20 10:08 output
$ ls -la output
total 12
drwxr-xr-x  2 bpursley bpursley 4096 Jul 20 10:08 .
drwxrwxr-x 11 bpursley bpursley 4096 Jul 20 10:08 ..
-rw-rw-r--  1 bpursley bpursley 2066 Jul 20 10:08 base64.xsd.java
```
```
$ go run cmd/xgen/xgen.go -l Java -i test/xsd
done
$ ls -la | grep xgen_out
drwxr-xr-x  2 bpursley bpursley  4096 Jul 20 10:09 xgen_out
$ ls -la xgen_out
total 12
drwxr-xr-x  2 bpursley bpursley 4096 Jul 20 10:09 .
drwxrwxr-x 11 bpursley bpursley 4096 Jul 20 10:09 ..
-rw-rw-r--  1 bpursley bpursley 2066 Jul 20 10:09 base64.xsd.java
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
