### PR TITLE
Added option to disable XML fields/import when using Go

### DIFF
--- a/cmd/xgen/xgen.go
+++ b/cmd/xgen/xgen.go
@@ -35,11 +35,12 @@ import (
 // Config holds user-defined overrides and filters that are used when
 // generating source code from an XSD document.
 type Config struct {
-	I       string
-	O       string
-	Pkg     string
-	Lang    string
-	Version string
+	I         string
+	O         string
+	Pkg       string
+	Lang      string
+	Version   string
+	NoXMLName bool
 }
 
 // Cfg are the default config for xgen. The default package name and output
@@ -62,13 +63,14 @@ var SupportLang = map[string]bool{
 func parseFlags() *Config {
 	iPtr := flag.String("i", "", "Input file path or directory for the XML schema definition")
 	oPtr := flag.String("o", "xgen_out", "Output file path or directory for the generated code")
+	noXmlName := flag.Bool("noxml", false, "Don't add xmlName fields")
 	pkgPtr := flag.String("p", "", "Specify the package name")
 	langPtr := flag.String("l", "", "Specify the language of generated code")
 	verPtr := flag.Bool("v", false, "Show version and exit")
 	helpPtr := flag.Bool("h", false, "Show this help and exit")
 	flag.Parse()
 	if *helpPtr {
-		fmt.Printf("xgen version: %s\r\nCopyright (c) 2020 - 2021 Ri Xu https://xuri.me All rights reserved.\r\n\r\nUsage:\r\n$ xgen [<flag> ...] <XSD file or directory> ...\n  -i <path>\tInput file path or directory for the XML schema definition\r\n  -o <path>\tOutput file path or directory for the generated code\r\n  -p     \tSpecify the package name\r\n  -l      \tSpecify the language of generated code (Go/C/Java/Rust/TypeScript)\r\n  -h     \tOutput this help and exit\r\n  -v     \tOutput version and exit\r\n", Cfg.Version)
+		fmt.Printf("xgen version: %s\r\nCopyright (c) 2020 - 2021 Ri Xu https://xuri.me All rights reserved.\r\n\r\nUsage:\r\n$ xgen [<flag> ...] <XSD file or directory> ...\n  -i <path>\tInput file path or directory for the XML schema definition\r\n  -o <path>\tOutput file path or directory for the generated code\r\n  -p     \tSpecify the package name\r\n  -l      \tSpecify the language of generated code (Go/C/Java/Rust/TypeScript)\r\n  --noxml     \tDon't generate XMLName fields on structs (Go)\r\n  -h     \tOutput this help and exit\r\n  -v     \tOutput version and exit\r\n", Cfg.Version)
 		os.Exit(0)
 	}
 	if *verPtr {
@@ -85,6 +87,9 @@ func parseFlags() *Config {
 		os.Exit(1)
 	}
 	Cfg.Lang = *langPtr
+	if *noXmlName {
+		Cfg.NoXMLName = *noXmlName
+	}
 	if *oPtr != "" {
 		Cfg.O = *oPtr
 	}
@@ -110,6 +115,7 @@ func main() {
 			FilePath:            file,
 			InputDir:            cfg.I,
 			OutputDir:           cfg.O,
+			NoXMLName:           cfg.NoXMLName,
 			Lang:                cfg.Lang,
 			Package:             cfg.Pkg,
 			IncludeMap:          make(map[string]bool),

--- a/genGo.go
+++ b/genGo.go
@@ -25,6 +25,7 @@ type CodeGenerator struct {
 	Package           string
 	ImportTime        bool // For Go language
 	ImportEncodingXML bool // For Go language
+	NoXMLName         bool // For Go language
 	ProtoTree         []interface{}
 	StructAST         map[string]string
 }
@@ -149,7 +150,7 @@ func (gen *CodeGenerator) GoSimpleType(v *SimpleType) {
 		if _, ok := gen.StructAST[v.Name]; !ok {
 			content := " struct {\n"
 			fieldName := genGoFieldName(v.Name, true)
-			if fieldName != v.Name {
+			if fieldName != v.Name && !gen.NoXMLName {
 				gen.ImportEncodingXML = true
 				content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
 			}
@@ -182,7 +183,7 @@ func (gen *CodeGenerator) GoComplexType(v *ComplexType) {
 	if _, ok := gen.StructAST[v.Name]; !ok {
 		content := " struct {\n"
 		fieldName := genGoFieldName(v.Name, true)
-		if fieldName != v.Name {
+		if fieldName != v.Name && !gen.NoXMLName {
 			gen.ImportEncodingXML = true
 			content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
 		}
@@ -250,7 +251,7 @@ func (gen *CodeGenerator) GoGroup(v *Group) {
 	if _, ok := gen.StructAST[v.Name]; !ok {
 		content := " struct {\n"
 		fieldName := genGoFieldName(v.Name, true)
-		if fieldName != v.Name {
+		if fieldName != v.Name && !gen.NoXMLName{
 			gen.ImportEncodingXML = true
 			content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
 		}
@@ -282,7 +283,7 @@ func (gen *CodeGenerator) GoAttributeGroup(v *AttributeGroup) {
 	if _, ok := gen.StructAST[v.Name]; !ok {
 		content := " struct {\n"
 		fieldName := genGoFieldName(v.Name, true)
-		if fieldName != v.Name {
+		if fieldName != v.Name && !gen.NoXMLName{
 			gen.ImportEncodingXML = true
 			content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
 		}

--- a/parser.go
+++ b/parser.go
@@ -26,6 +26,7 @@ type Options struct {
 	FileDir             string
 	InputDir            string
 	OutputDir           string
+	NoXMLName           bool
 	Extract             bool
 	Lang                string
 	Package             string
@@ -140,6 +141,7 @@ func (opt *Options) Parse() (err error) {
 			Lang:      opt.Lang,
 			Package:   opt.Package,
 			File:      path,
+			NoXMLName: opt.NoXMLName,
 			ProtoTree: opt.ProtoTree,
 			StructAST: map[string]string{},
 		}


### PR DESCRIPTION
## Description
Generated structs are given an XMLName field + encoding/xml import.
```
XMLName          xml.Name          `json:"XMLName"
```
Sometimes you may not want this, for example when using an XSD just to generate structs for some other application than XML-parsing.

This feature adds a commandline option to omit those fields:
```
  --noxml     	Don't generate XMLName fields on structs (Go)
```
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
