### PR TITLE
Support for optional element

### DIFF
--- a/genGo.go
+++ b/genGo.go
@@ -218,11 +218,15 @@ func (gen *CodeGenerator) GoComplexType(v *ComplexType) {
 			if element.Plural {
 				plural = "[]"
 			}
+			var optional string
+			if element.Optional {
+				optional = `,omitempty`
+			}
 			fieldType := genGoFieldType(getBasefromSimpleType(trimNSPrefix(element.Type), gen.ProtoTree))
 			if fieldType == "time.Time" {
 				gen.ImportTime = true
 			}
-			content += fmt.Sprintf("\t%s\t%s%s\t`xml:\"%s\"`\n", genGoFieldName(element.Name, false), plural, fieldType, element.Name)
+			content += fmt.Sprintf("\t%s\t%s%s\t`xml:\"%s%s\"`\n", genGoFieldName(element.Name, false), plural, fieldType, element.Name, optional)
 		}
 		if len(v.Base) > 0 {
 			// If the type is a built-in type, generate a Value field as chardata.

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -50,7 +50,7 @@ type MyType7 struct {
 type TopLevel struct {
 	CostAttr        float64    `xml:"cost,attr,omitempty"`
 	LastUpdatedAttr string     `xml:"LastUpdated,attr,omitempty"`
-	Nested          *MyType7   `xml:"nested"`
+	Nested          *MyType7   `xml:"nested,omitempty"`
 	MyType1         []string   `xml:"myType1"`
 	MyType2         []*MyType2 `xml:"myType2"`
 	*MyType6

--- a/test/rs/base64.xsd.rs
+++ b/test/rs/base64.xsd.rs
@@ -84,7 +84,7 @@ pub struct TopLevel {
 	#[serde(rename = "LastUpdated")]
 	pub last_updated: Option<u8>,
 	#[serde(rename = "nested")]
-	pub nested: MyType7,
+	pub nested: Option<MyType7>,
 	#[serde(rename = "myType1")]
 	pub my_type1: Vec<String>,
 	#[serde(rename = "myType2")]

--- a/xmlElement.go
+++ b/xmlElement.go
@@ -48,6 +48,11 @@ func (opt *Options) OnElement(ele xml.StartElement, protoTree []interface{}) (er
 				e.Plural = true
 			}
 		}
+		if attr.Name.Local == "minOccurs" {
+			if attr.Value == "0" {
+				e.Optional = true
+			}
+		}
 	}
 
 	if e.Type == "" {

--- a/xmlElement.go
+++ b/xmlElement.go
@@ -49,7 +49,11 @@ func (opt *Options) OnElement(ele xml.StartElement, protoTree []interface{}) (er
 			}
 		}
 		if attr.Name.Local == "minOccurs" {
-			if attr.Value == "0" {
+			var minOccurs int
+			if minOccurs, err = strconv.Atoi(attr.Value); err != nil {
+				return
+			}
+			if minOccurs == 0 {
 				e.Optional = true
 			}
 		}


### PR DESCRIPTION
# PR Details

Adds support for optional elements where `minOccurs=0`.

## Description

At present, elements have an `Optional` field that is never set during XSD parsing. This PR sets the field and adds support for it to the Go generator. The Rust generator already has it implemented.

Credit goes to geoko86 for the fix. I cherry-picked the commit from this PR: geoko86/xgen#1

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#47

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
XSD provides a way to express a tag that can be omitted without breaking the spec. That freedom does not make it into the generated code as it tends to always include tags whether or not they have been initialized.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this code on a Linux system using the existing test cases in this repository. The `TopLevel` element includes an optional element with `minOccurs="0" maxOccurs="1"`. The test's expected values however don't respect the `minOccurs`. The tests broke after making this change and worked again after changing the Go and Rust expected results to use their respective representations for optional elements.

I have also tested the Go code generated from a proprietary schema and verified that, after serializing the generated models, empty tags are no longer included.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
