### PR TITLE
make sequence mandate plural elements if maxOccurs is present

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -42,6 +42,7 @@ type Options struct {
 	InGroup          int
 	InUnion          bool
 	InAttributeGroup bool
+	InPluralSequence []bool
 
 	SimpleType     *Stack
 	ComplexType    *Stack

--- a/test/c/base64.xsd.h
+++ b/test/c/base64.xsd.h
@@ -34,6 +34,21 @@ typedef struct {
 	char OriginAttr; // attr
 } MyType7;
 
+// MyType8 ...
+typedef struct {
+	MyType4 Title[];
+} MyType8;
+
+// MyType9 ...
+typedef struct {
+	MyType4 Title[];
+} MyType9;
+
+// MyType10 ...
+typedef struct {
+	MyType4 Title;
+} MyType10;
+
 // TopLevel ...
 typedef struct {
 	float CostAttr; // attr, optional

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -46,6 +46,21 @@ type MyType7 struct {
 	Value      string `xml:",chardata"`
 }
 
+// MyType8 ...
+type MyType8 struct {
+	Title []*MyType4 `xml:"title"`
+}
+
+// MyType9 ...
+type MyType9 struct {
+	Title []*MyType4 `xml:"title"`
+}
+
+// MyType10 ...
+type MyType10 struct {
+	Title *MyType4 `xml:"title"`
+}
+
 // TopLevel ...
 type TopLevel struct {
 	CostAttr        float64    `xml:"cost,attr,omitempty"`

--- a/test/java/base64.xsd.java
+++ b/test/java/base64.xsd.java
@@ -68,6 +68,24 @@ public class MyType7 {
 	protected String value;
 }
 
+// MyType8 ...
+public class MyType8 {
+	@XmlElement(required = true, name = "title")
+	protected List<MyType4> Title;
+}
+
+// MyType9 ...
+public class MyType9 {
+	@XmlElement(required = true, name = "title")
+	protected List<MyType4> Title;
+}
+
+// MyType10 ...
+public class MyType10 {
+	@XmlElement(required = true, name = "title")
+	protected MyType4 Title;
+}
+
 // TopLevel ...
 public class TopLevel extends MyType6  {
 	@XmlAttribute(name = "cost")

--- a/test/rs/base64.xsd.rs
+++ b/test/rs/base64.xsd.rs
@@ -76,6 +76,30 @@ pub struct MyType7 {
 }
 
 
+// MyType8 ...
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct MyType8 {
+	#[serde(rename = "title")]
+	pub title: Vec<MyType4>,
+}
+
+
+// MyType9 ...
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct MyType9 {
+	#[serde(rename = "title")]
+	pub title: Vec<MyType4>,
+}
+
+
+// MyType10 ...
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct MyType10 {
+	#[serde(rename = "title")]
+	pub title: MyType4,
+}
+
+
 // TopLevel ...
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct TopLevel {

--- a/test/ts/base64.xsd.ts
+++ b/test/ts/base64.xsd.ts
@@ -37,6 +37,21 @@ export class MyType7 {
 	Value: string;
 }
 
+// MyType8 ...
+export class MyType8 {
+	Title: Array<MyType4>;
+}
+
+// MyType9 ...
+export class MyType9 {
+	Title: Array<MyType4>;
+}
+
+// MyType10 ...
+export class MyType10 {
+	Title: MyType4;
+}
+
 // TopLevel ...
 export class TopLevel extends MyType6  {
 	CostAttr: number | null;

--- a/test/xsd/base64.xsd
+++ b/test/xsd/base64.xsd
@@ -53,6 +53,24 @@
     </simpleContent>
   </complexType>
 
+  <complexType name="MyType8">
+    <sequence maxOccurs="unbounded">
+      <element name="title" type="here:myType4" />
+    </sequence>
+  </complexType>
+
+  <complexType name="MyType9">
+    <sequence maxOccurs="2">
+      <element name="title" type="here:myType4" />
+    </sequence>
+  </complexType>
+
+  <complexType name="MyType10">
+    <sequence maxOccurs="1">
+      <element name="title" type="here:myType4" />
+    </sequence>
+  </complexType>
+
   <element name="TopLevel">
     <complexType>
       <complexContent>

--- a/xmlElement.go
+++ b/xmlElement.go
@@ -50,6 +50,10 @@ func (opt *Options) OnElement(ele xml.StartElement, protoTree []interface{}) (er
 		}
 	}
 
+	if len(opt.InPluralSequence) > 0 && opt.InPluralSequence[len(opt.InPluralSequence)-1] {
+		e.Plural = true
+	}
+
 	if e.Type == "" {
 		e.Type, err = opt.GetValueType(e.Name, protoTree)
 		if err != nil {

--- a/xmlSequence.go
+++ b/xmlSequence.go
@@ -1,0 +1,41 @@
+// Copyright 2020 - 2024 The xgen Authors. All rights reserved. Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+//
+// Package xgen written in pure Go providing a set of functions that allow you
+// to parse XSD (XML schema files). This library needs Go version 1.10 or
+// later.
+
+package xgen
+
+import (
+	"encoding/xml"
+	"strconv"
+)
+
+// OnSequence evaluates wether the sequence element contains a maxOccurs attribute
+// (that in turn mandates plural inner elements) and saves that info on a stack
+func (opt *Options) OnSequence(ele xml.StartElement, protoTree []interface{}) (err error) {
+	for _, attr := range ele.Attr {
+		if attr.Name.Local == "maxOccurs" {
+			if attr.Value == "unbounded" {
+				opt.InPluralSequence = append(opt.InPluralSequence, true)
+				return nil
+			}
+
+			var maxOccurs int
+			if maxOccurs, err = strconv.Atoi(attr.Value); err == nil && maxOccurs > 1 {
+				opt.InPluralSequence = append(opt.InPluralSequence, true)
+				return nil
+			}
+		}
+	}
+	opt.InPluralSequence = append(opt.InPluralSequence, false)
+	return nil
+}
+
+// EndSequence removes an item from the stack mentioned above
+func (opt *Options) EndSequence(ele xml.EndElement, protoTree []interface{}) (err error) {
+	opt.InPluralSequence = opt.InPluralSequence[:len(opt.InPluralSequence)-1]
+	return
+}


### PR DESCRIPTION
# PR Details

Make sequence maxOccurs supported on a sequence element

## Description

When maxOccurs is present on a sequence, the inner elements can be repeated, so they should be of plural type

## Related Issue

Fixes half of #47 

## Motivation and Context

I had the occurrence of an .xsd with maxOccurs on a sequence on a spec 

## How Has This Been Tested

Implemented test cases, tried it at my own case, where it works too. Does not seem to change other test cases.
I'm not an expert in .xsd's and the workings of xgen, but i had the feeling, that a problem could occur, where nested sequence elements could be of different types (plural vs. singular) and i should have covered that in the code, but i'm not really sure how to write a test for it - suggestions welcome.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
