### PR TITLE
This fixes #86, Duplicated field in the generated code

### DIFF
--- a/xmlElement.go
+++ b/xmlElement.go
@@ -93,9 +93,16 @@ func (opt *Options) OnElement(ele xml.StartElement, protoTree []interface{}) (er
 
 // EndElement handles parsing event on the element end elements.
 func (opt *Options) EndElement(ele xml.EndElement, protoTree []interface{}) (err error) {
-	if opt.Element.Len() > 0 && opt.ComplexType.Len() == 0 {
+	if opt.Element.Len() == 0 {
+		return
+	}
+
+	if opt.ComplexType.Len() > 0 {
+		opt.Element.Pop()
+	} else {
 		opt.ProtoTree = append(opt.ProtoTree, opt.Element.Pop())
 	}
+
 	return
 }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description
The problem happens due to the combination of two lines of code:
1.  `xmlElement.go:58`:
	- `opt.Element.Push(&e)`
			This line inserts an element in Element stack, to indicate that we are inside `<element></element>`.
2. `xmlRestriction.go:49`:
	- `opt.ComplexType.Peek().(*ComplexType).Elements[len(opt.ComplexType.Peek().(*ComplexType).Elements)-1] = *opt.Element.Peek().(*Element)`
		 This replaces the last element of `ComplexType.Elements`. 

The problem occurs because when some element neither has a `type` attribute nor contains a restriction (which is valid), the elements were not popped properly (when they were pushed only because they had no name). And when a restriction is found, the second code mentioned runs, replacing the last element.

It's good to know that it only happens with an attribute because, if the restriction is an element, like this:
```xsd
<element name="ElementWithRestriction">
	<simpleType>
		<restriction base="string" />
	</simpleType>
</element>

```
the restriction handling code runs, but the `*opt.Element.Peek().(*Element)` refers to itself, in other words, replacing the last element (itself) with itself.

The solution I found to solve this problem is like the solution proposed by @senekor (https://github.com/xuri/xgen/issues/5), that simply pops the element at the end:
```Go
if opt.Element.Len() > 0 && opt.ComplexType.Len() > 0 {
     opt.Element.Pop()
}
```

His problem is not the same as mine, but the root cause is: the opt.Element stack.
With the above solution, the code stops generating the same field twice, because there are no remnant elements.

## Related Issue
https://github.com/xuri/xgen/issues/86

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
