### PR TITLE
This closes #88, simpleType causing issues in the generated code

### DIFF
--- a/xmlRestriction.go
+++ b/xmlRestriction.go
@@ -22,6 +22,11 @@ func (opt *Options) OnRestriction(ele xml.StartElement, protoTree []interface{})
 				return
 			}
 			if opt.SimpleType.Peek() != nil {
+				if opt.Element.Len() > 0 {
+					opt.Element.Peek().(*Element).Type, err = opt.GetValueType(valueType, protoTree)
+					return
+				}
+
 				opt.SimpleType.Peek().(*SimpleType).Base, err = opt.GetValueType(valueType, protoTree)
 				if err != nil {
 					return

--- a/xmlSimpleType.go
+++ b/xmlSimpleType.go
@@ -20,9 +20,9 @@ func (opt *Options) OnSimpleType(ele xml.StartElement, protoTree []interface{}) 
 	if opt.CurrentEle == "attributeGroup" {
 		// return
 	}
-	opt.CurrentEle = opt.InElement
 	for _, attr := range ele.Attr {
 		if attr.Name.Local == "name" {
+			opt.CurrentEle = opt.InElement
 			opt.SimpleType.Peek().(*SimpleType).Name = attr.Value
 		}
 	}


### PR DESCRIPTION
# PR Details

## Description

The line in the outer position of 'if' causes the `simpleType` element to be set to `CurrentEle` every time it is parsed. However, `simpleType` is not always the parent of all nested elements. If I have the following relationship as an example:
```xsd
<element name="ElementWithSimpleType">
    <simpleType>
        <restriction base="string" />
    </simpleType>
</element>

```
 then `CurrentEle` should be the element, not "simpleType". **The attribute `name` defines the correct parent.**

With this, the problem occurs when `EndSimpleType` is called, because `CurrentEle` is set to "simpleType", which it shouldn't be, incorrectly adding this `simpleType` element to `ProtoTree`.

## Related Issue
#88

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
