### PR TITLE
Fix missing Doc for ComplexType in XSD

### DIFF
--- a/xmlComplexType.go
+++ b/xmlComplexType.go
@@ -16,6 +16,7 @@ func (opt *Options) OnComplexType(ele xml.StartElement, protoTree []interface{})
 	if opt.ComplexType.Len() > 0 {
 		e := opt.Element.Pop().(*Element)
 		opt.ComplexType.Push(&ComplexType{
+			Doc:  e.Doc,
 			Name: e.Name,
 		})
 	}
@@ -28,9 +29,12 @@ func (opt *Options) OnComplexType(ele xml.StartElement, protoTree []interface{})
 				c.Name = attr.Value
 			}
 		}
-		if c.Name == "" {
+		if opt.Element.Len() > 0 {
 			e := opt.Element.Pop().(*Element)
-			c.Name = e.Name
+			c.Doc = e.Doc
+			if c.Name == "" {
+				c.Name = e.Name
+			}
 		}
 		opt.ComplexType.Push(&c)
 	}


### PR DESCRIPTION
# PR Details

The content of the documentation for some types in the input XSD is missing because of parsing issues

## Description

Given XSD:
```xml
<?xml version="1.0" encoding="utf-8"?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
    <xs:element name="Blog">
        <xs:annotation>
            <xs:documentation>Blog content</xs:documentation>
        </xs:annotation>
        <xs:complexType>
            <xs:sequence>
                <xs:element name="Post" maxOccurs="1000">
                    <xs:annotation>
                        <xs:documentation>Posts in blog</xs:documentation>
                    </xs:annotation>
                </xs:element>
            </xs:sequence>
            <xs:attribute name="CreatedAt" type="xs:date" use="required">
                <xs:annotation>
                    <xs:documentation>Date of creation</xs:documentation>
                </xs:annotation>
            </xs:attribute>
        </xs:complexType>
    </xs:element>
</xs:schema>
```
xgen generate go types (note the comment before struct):
```golang
// Code generated by xgen. DO NOT EDIT.

package schema

// Blog ...
type Blog struct {
	CreatedAtAttr string  `xml:"CreatedAt,attr"`
	Post          []*Post `xml:"Post"`
}

// Post is Date of creation
type Post []*Post
```

While the expected result:
```golang
// Code generated by xgen. DO NOT EDIT.

package schema

// Blog is Blog content
type Blog struct {
	CreatedAtAttr string  `xml:"CreatedAt,attr"`
	Post          []*Post `xml:"Post"`
}

// Post is Date of creation
type Post []*Post
```

## Motivation and Context

This fix helps to transform a 3k+ XSD file and keep documentation to avoid tons of manual work.

## How Has This Been Tested

All existing tests passed.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
