### PR TITLE
PascalCase golang gen

### DIFF
--- a/genGo.go
+++ b/genGo.go
@@ -110,7 +110,6 @@ func genGoFieldName(name string, unique bool) (fieldName string) {
 			fieldName = fmt.Sprintf("%s%d", fieldName, count)
 		}
 	}
-
 	return
 }
 
@@ -118,16 +117,13 @@ func genGoFieldType(name string) string {
 	if _, ok := goBuildinType[name]; ok {
 		return name
 	}
-
 	var fieldType string
 	for _, str := range strings.FieldsFunc(name, splitter) {
 		fieldType += MakeFirstUpperCase(str)
 	}
-
 	if fieldType != "" {
 		return "*" + fieldType
 	}
-
 	return "interface{}"
 }
 


### PR DESCRIPTION
# PR Details

generated go types and fields aren't properly capitalized when xsd uses _ or - ending up in names like Dateexpiration instead of DateExpiration etc.

## Description

capitalizes first letter after every split

## Motivation and Context

will make generated go code more readable

## How Has This Been Tested

tested on xsd using - and _ in field names

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
