### PR TITLE
Golang: Support Optional Fields as Pointers

### DIFF
--- a/genGo.go
+++ b/genGo.go
@@ -224,6 +224,9 @@ func (gen *CodeGenerator) GoComplexType(v *ComplexType) {
 			if fieldType == "time.Time" {
 				gen.ImportTime = true
 			}
+			if element.Optional && !strings.HasPrefix(fieldType, `*`) {
+				fieldType = "*" + fieldType
+			}
 			content += fmt.Sprintf("\t%s\t%s%s\t`xml:\"%s%s\"`\n", genGoFieldName(element.Name, false), plural, fieldType, element.Name, optional)
 		}
 		if len(v.Base) > 0 {

--- a/test/c/base64.xsd.h
+++ b/test/c/base64.xsd.h
@@ -18,6 +18,7 @@ typedef struct {
 	char Title;
 	char Blob[];
 	char Timestamp;
+	char Metadata;
 } MyType4;
 
 // MyType5 ...

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -29,6 +29,7 @@ type MyType4 struct {
 	Title     string   `xml:"title"`
 	Blob      string   `xml:"blob"`
 	Timestamp string   `xml:"timestamp"`
+	Metadata  *string  `xml:"metadata,omitempty"`
 }
 
 // MyType5 ...

--- a/test/java/base64.xsd.java
+++ b/test/java/base64.xsd.java
@@ -43,6 +43,8 @@ public class MyType4 {
 	protected List<Byte> Blob;
 	@XmlElement(required = true, name = "timestamp")
 	protected String Timestamp;
+	@XmlElement(required = true, name = "metadata")
+	protected String Metadata;
 }
 
 // MyType5 ...

--- a/test/rs/base64.xsd.rs
+++ b/test/rs/base64.xsd.rs
@@ -43,6 +43,8 @@ pub struct MyType4 {
 	pub blob: String,
 	#[serde(rename = "timestamp")]
 	pub timestamp: u8,
+	#[serde(rename = "metadata")]
+	pub metadata: Option<String>,
 }
 
 

--- a/test/ts/base64.xsd.ts
+++ b/test/ts/base64.xsd.ts
@@ -20,6 +20,7 @@ export class MyType4 {
 	Title: string;
 	Blob: Uint8Array;
 	Timestamp: string;
+	Metadata: string;
 }
 
 // MyType5 ...

--- a/test/xsd/base64.xsd
+++ b/test/xsd/base64.xsd
@@ -26,6 +26,7 @@
       <element name="title" type="string"/>
       <element name="blob" type="base64Binary"/>
       <element name="timestamp" type="dateTime"/>
+      <element name="metadata" type="string" minOccurs="0" />
     </sequence>
   </complexType>
 


### PR DESCRIPTION
# PR Details

Extends optional element support in Golang.

## Description

Changes the Golang generator to make optional fields as pointers

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

An XSD can be defined to have optional elements (such as minOccurences=0). When this happens, its unclear on parsing if the value was truly unset in the xml, or given the zero value. Null-able optional fields allows developers to differentiate.

## How Has This Been Tested

Locally ran all tests after updating generation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
   - I think this could not be made a non-breaking change if a command line flag was also added. I did not do this - but will if requested.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
